### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
 # app-dev
+My first repository 
+
+###Train to busan (2018)
+A man (Gong Yoo), his estranged daughter and other passengers become trapped on a speeding train during a zombie outbreak in South Korea.
+
+###dead pool 2 (2018)
+Wisecracking mercenary Deadpool meets Russell, an angry teenage mutant who lives at an orphanage. When Russell becomes the target of Cable -- a genetically enhanced soldier from the future -- Deadpool realizes that he'll need some help saving the boy from such a superior enemy. He soon joins forces with Bedlam, Shatterstar, Domino and other powerful mutants to protect young Russell from Cable and his advanced weaponry.
+
+###zombie land 2 (2019)
+Zombie slayers Tallahassee, Columbus, Wichita and Little Rock leave the confines of the White House to travel to Graceland in Memphis, Tenn. Along the way, they encounter other post-apocalyptic warriors and a group of survivors who find refuge in a commune.


### PR DESCRIPTION
Train to Busan is a 2016 South Korean action horror film about a group of passengers on a train from Seoul to Busan who are trying to survive a zombie apocalypse. The movie stars Gong Yoo, Jung Yu-mi, and Ma Dong-seok, and was directed by Yeon Sang-ho. 
Here are some details about Train to Busan:
Plot
A zombie outbreak breaks out in South Korea, and a father and daughter try to reach the only safe city on a train. 
Violence
The movie contains intense, bloody violence, and scenes of people falling from helicopters and a train crash. 
Content rating
Train to Busan has a content rating of severe violence and gore, mild profanity, and severe frightening and intense scenes. 
Awards
Train to Busan won 36 awards and was nominated for 42. 
Sequels
Train to Busan has an animated prequel, Seoul Station, and a standalone sequel, Peninsula. Another installment and an American adaptation are in development. 
You can watch Train to Busan on Netflix. 
